### PR TITLE
Enable cgroups memory hierarchy

### DIFF
--- a/cgroupfs-mount
+++ b/cgroupfs-mount
@@ -51,4 +51,11 @@ done
 #  freezer	7	3	1
 #  blkio	8	3	1
 
+# enable cgroups memory hierarchy, like systemd does (and lxc/docker desires)
+# https://github.com/systemd/systemd/blob/v245/src/core/cgroup.c#L2983
+# https://bugs.debian.org/940713
+if [ -e /sys/fs/cgroup/memory/memory.use_hierarchy ]; then
+	echo 1 > /sys/fs/cgroup/memory/memory.use_hierarchy
+fi
+
 exit 0


### PR DESCRIPTION
Was thinking of merging this [in a downstream repo](https://github.com/openwrt/packages/tree/master/utils/cgroupfs-mount) but it appears that this is a wider issue for non-systemd users so figured it would be better suited here.

Debian issue: [#940713](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=940713)