### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/cgroupfs-mount.maintscript
+++ b/debian/cgroupfs-mount.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/init/cgroupfs-mount.conf 1.4~

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,9 @@ cgroupfs-mount (1.5) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
   * Bump debhelper from old 9 to 12.
+  * Remove constraints unnecessary since buster:
+    + cgroupfs-mount: Drop versioned constraint on lsb-base in Depends.
+    + Remove 1 maintscript entries from 1 files.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 31 Oct 2019 17:36:19 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/tianon/cgroupfs-mount
 Package: cgroupfs-mount
 Architecture: all
 Multi-Arch: foreign
-Depends: lsb-base (>= 3.0-6), ${misc:Depends}
+Depends: lsb-base, ${misc:Depends}
 Description: Light-weight package to set up cgroupfs mounts
  Control groups are a kernel mechanism for tracking and imposing
  limits on resource usage on groups of tasks.


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/cgroupfs-mount/ac80191b-85b0-4d65-aecc-96cbbb0c8697.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/preinst
### Control files: lines which differ (wdiff format)
* Depends: lsb-base [-(>= 3.0-6)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ac80191b-85b0-4d65-aecc-96cbbb0c8697/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ac80191b-85b0-4d65-aecc-96cbbb0c8697/diffoscope)).
